### PR TITLE
fix new post connect to state

### DIFF
--- a/blog/src/components/posts_new.js
+++ b/blog/src/components/posts_new.js
@@ -73,7 +73,14 @@ function validate(values) {
   return errors;
 }
 
-export default reduxForm({
-  validate,
-  form: "PostsNewForm"
-})(connect(null, { createPost })(PostsNew));
+export default connect(
+  null,
+  { createPost }
+)(
+  reduxForm({
+      validate,
+      form: "PostsNewForm",
+      enableReinitialize: true
+  })
+  (PostsNew)
+);


### PR DESCRIPTION
Hello, after attempting to apply initial values to a redux form I've noticed that it didn't work when I've followed the new post example. The problem was the order in which the components were wrapped.

First we need to wrap the Form component with reduxForm and then connect it to the redux store.

export default reduxForm({
validate,
form: "PostsNewForm"
})(connect(null, { createPost })(PostsNew));

should be

export default connect(null, { createPost })(
reduxForm({
validate,
form: "PostsNewForm"
})(PostsNew));