### PR TITLE
Resolves issue #20.  Bug in spark-lines plugin.

### DIFF
--- a/weather/package.json
+++ b/weather/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^0.14.3",
     "react-google-maps": "^4.7.1",
     "react-redux": "^4.0.0",
-    "react-sparklines": "^1.4.2",
+    "react-sparklines": "~1.6.0",
     "redux": "^3.0.4",
     "redux-promise": "^0.5.0"
   }


### PR DESCRIPTION
Version 1.7 of react-sparklines contains a bug.  Using only minor version increase of 1.6 resolves the issue.

More detail here:  https://github.com/borisyankov/react-sparklines/issues/89